### PR TITLE
Expand ui-request.edit subpermissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
         "permissionName": "ui-request.edit",
         "displayName": "Request: Edit requests",
         "subPermissions": [
-          "rs.patronrequests.item.put"
+          "rs.patronrequests.item.put",
+          "rs.patronrequests.item.performaction"
         ],
         "visible": "true"
       }


### PR DESCRIPTION
Added "rs.patronrequests.item.performaction" to the subpermissions of this, to permit editors to perform actions on existing requests.